### PR TITLE
fix isDate check issue for wxc-page-calendar

### DIFF
--- a/packages/wxc-page-calendar/format.js
+++ b/packages/wxc-page-calendar/format.js
@@ -44,8 +44,7 @@ export function _getTraditionalHoliday () {
 }
 
 export function _isDate (obj) {
-  const type = obj === null ? String(obj) : {}.toString.call(obj) || 'object';
-  return type === '[object date]';
+  return obj instanceof Date;
 }
 
 /**


### PR DESCRIPTION
```js
  return type === '[object date]';
```
the type for Date should be '[object Date]'

Here use `instanceof` instead of type